### PR TITLE
Fix/ts event emitter and copilot indentation

### DIFF
--- a/after/plugin/copilot.lua
+++ b/after/plugin/copilot.lua
@@ -1,0 +1,34 @@
+-- after/plugin/copilot.lua
+-- Ensures Copilot respects file-specific indentation settings
+
+local function setup_copilot_indentation()
+  -- Detect indentation settings from the current buffer
+  local indent_size = vim.bo.tabstop
+  local use_spaces = vim.bo.expandtab
+  
+  -- Update Copilot's indentation settings
+  vim.g.copilot_tab_spaces = indent_size
+  vim.g.copilot_indent_mode = use_spaces and 'space' or 'tab'
+  
+  -- Conditionally update copilot.vim parameters if it exposes an API method
+  if vim.fn.exists('*copilot#SetIndentation') == 1 then
+    vim.fn['copilot#SetIndentation'](indent_size, use_spaces)
+  end
+end
+
+-- Create autocmds to update settings when needed
+vim.api.nvim_create_augroup("CopilotIndentation", { clear = true })
+
+vim.api.nvim_create_autocmd({"BufEnter", "FileType"}, {
+  group = "CopilotIndentation",
+  callback = setup_copilot_indentation
+})
+
+-- Run when Copilot initializes
+vim.api.nvim_create_autocmd("User", {
+  pattern = "CopilotReady",
+  callback = setup_copilot_indentation,
+})
+
+-- Initial setup
+setup_copilot_indentation()

--- a/after/plugin/copilot.lua
+++ b/after/plugin/copilot.lua
@@ -28,6 +28,7 @@ vim.api.nvim_create_autocmd({"BufEnter", "FileType"}, {
 
 -- Run when Copilot initializes
 vim.api.nvim_create_autocmd("User", {
+  group = "CopilotIndentation",
   pattern = "CopilotReady",
   callback = setup_copilot_indentation,
 })

--- a/after/plugin/copilot.lua
+++ b/after/plugin/copilot.lua
@@ -4,6 +4,8 @@
 local function setup_copilot_indentation()
   -- Detect indentation settings from the current buffer
   local indent_size = vim.bo.tabstop
+  -- Ensure indent_size is within reasonable bounds
+  indent_size = math.max(1, math.min(8, indent_size))
   local use_spaces = vim.bo.expandtab
   
   -- Update Copilot's indentation settings

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -7,10 +7,6 @@ vim.g.copilot_no_tab_map = true          -- Disable default tab mapping
 vim.g.copilot_assume_mapped = true       -- Tell Copilot we have custom mappings
 vim.g.copilot_tab_fallback = ""          -- What to do when tab is pressed and Copilot has no suggestion
 
--- Add indentation settings
-vim.g.copilot_indent_mode = 'current'    -- Use the current file's indentation
-vim.g.copilot_tab_spaces = vim.opt.tabstop:get() -- Match Neovim's tab settings
-
 -- Suggestion display settings
 vim.g.copilot_filetypes = {              -- Enable/disable for specific filetypes
   ["*"] = true,                          -- Enable for all filetypes by default
@@ -43,4 +39,4 @@ vim.api.nvim_create_user_command('CopilotToggle', function()
   end
 end, {})
 
--- Note: The more detailed indentation sync is in after/plugin/copilot.lua
+-- Note: Indentation settings are handled in after/plugin/copilot.lua

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -7,6 +7,10 @@ vim.g.copilot_no_tab_map = true          -- Disable default tab mapping
 vim.g.copilot_assume_mapped = true       -- Tell Copilot we have custom mappings
 vim.g.copilot_tab_fallback = ""          -- What to do when tab is pressed and Copilot has no suggestion
 
+-- Add indentation settings
+vim.g.copilot_indent_mode = 'current'    -- Use the current file's indentation
+vim.g.copilot_tab_spaces = vim.opt.tabstop:get() -- Match Neovim's tab settings
+
 -- Suggestion display settings
 vim.g.copilot_filetypes = {              -- Enable/disable for specific filetypes
   ["*"] = true,                          -- Enable for all filetypes by default
@@ -39,8 +43,4 @@ vim.api.nvim_create_user_command('CopilotToggle', function()
   end
 end, {})
 
-
-
-
-
-
+-- Note: The more detailed indentation sync is in after/plugin/copilot.lua

--- a/lua/plugins/lsp/mason.lua
+++ b/lua/plugins/lsp/mason.lua
@@ -11,6 +11,16 @@ function M.setup(opts)
   ok, mason_lspconfig  = pcall(require, "mason-lspconfig"); if not ok then vim.notify("mason-lspconfig not found!", "error"); return end
   ok, lspconfig        = pcall(require, "lspconfig");       if not ok then vim.notify("lspconfig not found!", "error");       return end
 
+  -- Load the TypeScript server wrapper for EventEmitter fix
+  local ts_wrapper_ok, ts_wrapper = pcall(require, "plugins.lsp.ts_server_wrapper")
+  local ts_server_opts = {}
+  if ts_wrapper_ok then
+    ts_server_opts = ts_wrapper.setup()
+    logger.info("TypeScript server wrapper loaded for EventEmitter fix")
+  else
+    logger.warn("TypeScript server wrapper not found, EventEmitter warning may persist")
+  end
+
   -- mason core ---------------------------------------------------------------
   mason.setup({
     ui = {
@@ -71,11 +81,11 @@ function M.setup(opts)
       single_file_support = true,
     },
 
-    ts_ls = { -- typescript-language-server :contentReference[oaicite:0]{index=0}
+    ts_ls = vim.tbl_deep_extend("force", ts_server_opts, {
       settings = {
         -- put extra ts settings here if you need them
       },
-    },
+    }),
   }
 
   -- mason-lspconfig glue -----------------------------------------------------
@@ -103,10 +113,8 @@ function M.setup(opts)
 
   -- optional debug -----------------------------------------------------------
   vim.defer_fn(function()
-
      logger.info("mason initialised ➜ " .. paths.join(vim.fn.stdpath("data"), "mason"), "info")
   end, 1000)
 end
 
 return M
-

--- a/lua/plugins/lsp/mason.lua
+++ b/lua/plugins/lsp/mason.lua
@@ -15,7 +15,10 @@ function M.setup(opts)
   local ts_wrapper_ok, ts_wrapper = pcall(require, "plugins.lsp.ts_server_wrapper")
   local ts_server_opts = {}
   if ts_wrapper_ok then
-    ts_server_opts = ts_wrapper.setup()
+    -- Pass configuration to the wrapper with a specific max_listeners value
+    ts_server_opts = ts_wrapper.setup({
+      max_listeners = 15  -- Configurable value for EventEmitter max listeners
+    })
     logger.info("TypeScript server wrapper loaded for EventEmitter fix")
   else
     logger.warn("TypeScript server wrapper not found, EventEmitter warning may persist")

--- a/lua/plugins/lsp/ts_server_wrapper.lua
+++ b/lua/plugins/lsp/ts_server_wrapper.lua
@@ -1,12 +1,15 @@
 -- lua/plugins/lsp/ts_server_wrapper.lua
 local M = {}
 
-function M.setup()
+function M.setup(config)
+  config = config or {}
+  local max_listeners = config.max_listeners or 15
+  
   -- Ensure the process.env exists before starting the server
-  local env_prepare = [[
+  local env_prepare = string.format([[
   process.setMaxListeners = process.setMaxListeners || function() {};
-  require('events').EventEmitter.defaultMaxListeners = 15;
-  ]]
+  require('events').EventEmitter.defaultMaxListeners = %d;
+  ]], max_listeners)
   
   return {
     before_init = function(params, config)

--- a/lua/plugins/lsp/ts_server_wrapper.lua
+++ b/lua/plugins/lsp/ts_server_wrapper.lua
@@ -4,15 +4,15 @@ local M = {}
 function M.setup(config)
   config = config or {}
   local max_listeners = config.max_listeners or 15
-  
+
   -- Ensure the process.env exists before starting the server
   local env_prepare = string.format([[
   process.setMaxListeners = process.setMaxListeners || function() {};
   require('events').EventEmitter.defaultMaxListeners = %d;
   ]], max_listeners)
-  
+
   return {
-    before_init = function(params, config)
+    before_init = function(params)
       -- Inject our env preparation script before server initialization
       params.initializationOptions = params.initializationOptions or {}
       params.initializationOptions.beforeServerStart = env_prepare

--- a/lua/plugins/lsp/ts_server_wrapper.lua
+++ b/lua/plugins/lsp/ts_server_wrapper.lua
@@ -1,0 +1,21 @@
+-- lua/plugins/lsp/ts_server_wrapper.lua
+local M = {}
+
+function M.setup()
+  -- Ensure the process.env exists before starting the server
+  local env_prepare = [[
+  process.setMaxListeners = process.setMaxListeners || function() {};
+  require('events').EventEmitter.defaultMaxListeners = 15;
+  ]]
+  
+  return {
+    before_init = function(params, config)
+      -- Inject our env preparation script before server initialization
+      params.initializationOptions = params.initializationOptions or {}
+      params.initializationOptions.beforeServerStart = env_prepare
+      return params
+    end
+  }
+end
+
+return M

--- a/lua/plugins/lsp/ts_server_wrapper.lua
+++ b/lua/plugins/lsp/ts_server_wrapper.lua
@@ -1,4 +1,13 @@
 -- lua/plugins/lsp/ts_server_wrapper.lua
+--
+-- TypeScript LSP server wrapper to fix EventEmitter warnings
+--
+-- This module injects configuration to increase the EventEmitter default max listeners
+-- limit to prevent "MaxListenersExceededWarning" in Node.js TypeScript server.
+-- 
+-- Available options:
+--   config.max_listeners - Number of max listeners (default: 15)
+--
 local M = {}
 
 function M.setup(config)


### PR DESCRIPTION

This PR addresses two issues in the Neovim configuration:

### 1. Fix EventEmitter Warning in TypeScript Language Server

The TypeScript language server was generating a warning about EventEmitter memory leaks:
```
(node:5552) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 change listeners added to [EventEmitter]. MaxListeners is 10.
```

The fix involves:
- Adding a new `ts_server_wrapper.lua` file that increases the EventEmitter default limit to 15
- Updating the Mason configuration to use this wrapper for the TypeScript language server

### 2. Improve Copilot Indentation Synchronization

Copilot was using different indentation levels than the Neovim editor settings. The fix involves:

- Adding indentation settings to the core Copilot configuration
- Creating a more robust indentation synchronization system in `after/plugin/copilot.lua` that:
  - Detects the current buffer's indentation settings (spaces vs tabs, tab size)
  - Updates Copilot's settings to match
  - Automatically synchronizes when:
    - Copilot initializes
    - The user changes buffers
    - The file type changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Automatically synchronizes GitHub Copilot's indentation settings with the current buffer's configuration in Neovim.
	- Introduced a TypeScript language server wrapper to manage Node.js EventEmitter max listeners, reducing related warnings.
- **Bug Fixes**
	- Addresses and suppresses EventEmitter max listeners warnings for the TypeScript language server.
- **Chores**
	- Updated documentation comments to clarify Copilot indentation settings management location.
	- Removed unnecessary blank lines for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->